### PR TITLE
Add Save and Save As actions with unsaved-change prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Eclipse PDF
+
+Electron-based PDF viewer/editor with save and save-as features.

--- a/main.js
+++ b/main.js
@@ -127,6 +127,22 @@ ipcMain.on('save-file', (_event, filePath, dataBuffer) => {
   }
 });
 
+ipcMain.handle('save-file-as', async (_event, defaultPath, dataBuffer) => {
+  try {
+    const { canceled, filePath } = await dialog.showSaveDialog({
+      title: 'Save PDF As',
+      defaultPath,
+      filters: [{ name: 'PDF Files', extensions: ['pdf'] }]
+    });
+    if (canceled || !filePath) return null;
+    fs.writeFileSync(filePath, Buffer.from(dataBuffer));
+    return toFileUrl(filePath);
+  } catch (err) {
+    console.error('Failed to save as:', err);
+    return null;
+  }
+});
+
 async function promptToSave(win, next) {
   try {
     const hasUnsaved = await win.webContents.executeJavaScript(

--- a/main.js
+++ b/main.js
@@ -150,9 +150,9 @@ async function promptToSave(win, next) {
     );
     if (!hasUnsaved) {
       await next();
-      return;
+      return true;
     }
-    const { response } = await dialog.showMessageBox(win, {
+    const response = dialog.showMessageBoxSync(win, {
       type: 'question',
       buttons: ['Save', "Don't Save", 'Cancel'],
       defaultId: 0,
@@ -162,12 +162,17 @@ async function promptToSave(win, next) {
     if (response === 0) {
       await win.webContents.executeJavaScript('window.__saveCurrent?.()').catch(() => {});
       await next();
-    } else if (response === 1) {
-      await next();
+      return true;
     }
+    if (response === 1) {
+      await next();
+      return true;
+    }
+    return false;
   } catch (e) {
     console.error('promptToSave failed:', e);
     await next();
+    return true;
   }
 }
 

--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@ const { app, BrowserWindow, ipcMain, dialog, shell, Menu } = require('electron')
 const path = require('path');
 const fs = require('fs');
 const axios = require('axios');
-const { pathToFileURL } = require('url');
+const { pathToFileURL, fileURLToPath } = require('url');
 
 if (process.platform === 'win32') {
   app.setAppUserModelId('com.eclipsepdf.app');
@@ -117,9 +117,43 @@ ipcMain.handle('select-pdf', async () => {
   return toFileUrl(filePaths[0]);
 });
 ipcMain.on('save-file', (_event, filePath, dataBuffer) => {
-  try { fs.writeFileSync(filePath, Buffer.from(dataBuffer)); }
-  catch (err) { console.error('Failed to save file:', err); }
+  try {
+    if (typeof filePath === 'string' && filePath.startsWith('file://')) {
+      filePath = fileURLToPath(filePath);
+    }
+    fs.writeFileSync(filePath, Buffer.from(dataBuffer));
+  } catch (err) {
+    console.error('Failed to save file:', err);
+  }
 });
+
+async function promptToSave(win, next) {
+  try {
+    const hasUnsaved = await win.webContents.executeJavaScript(
+      '(()=>{try{return !!(window.__hasUnsavedChanges && window.__hasUnsavedChanges());}catch(e){return false;}})()'
+    );
+    if (!hasUnsaved) {
+      await next();
+      return;
+    }
+    const { response } = await dialog.showMessageBox(win, {
+      type: 'question',
+      buttons: ['Save', "Don't Save", 'Cancel'],
+      defaultId: 0,
+      cancelId: 2,
+      message: 'You have unsaved changes. What would you like to do?'
+    });
+    if (response === 0) {
+      await win.webContents.executeJavaScript('window.__saveCurrent?.()').catch(() => {});
+      await next();
+    } else if (response === 1) {
+      await next();
+    }
+  } catch (e) {
+    console.error('promptToSave failed:', e);
+    await next();
+  }
+}
 
 function firstExisting(paths) { return paths.find(p => p && fs.existsSync(p)); }
 function getIconPath() {
@@ -154,25 +188,27 @@ function setViewerMenu(win) {
         {
           label: 'Back to Home',
           accelerator: 'Alt+Left',
-          click: () => {
+          click: async () => {
             if (!win) return;
-            win.webContents.once('will-prevent-unload', e => e.preventDefault());
-            win.loadFile('file-picker.html');
+            await promptToSave(win, () => win.loadFile('file-picker.html'));
           }
         },
         {
           label: 'Open PDF…',
           accelerator: 'CmdOrCtrl+O',
           click: async () => {
-            const { canceled, filePaths } = await dialog.showOpenDialog({
-              title: 'Open PDF',
-              properties: ['openFile'],
-              filters: [{ name: 'PDF Files', extensions: ['pdf'] }]
+            if (!win) return;
+            await promptToSave(win, async () => {
+              const { canceled, filePaths } = await dialog.showOpenDialog({
+                title: 'Open PDF',
+                properties: ['openFile'],
+                filters: [{ name: 'PDF Files', extensions: ['pdf'] }]
+              });
+              if (!canceled && filePaths?.[0]) {
+                const url = toFileUrl(filePaths[0]);
+                win.webContents.send('open-pdf', url);
+              }
             });
-            if (!canceled && filePaths?.[0]) {
-              const url = toFileUrl(filePaths[0]);
-              win.webContents.send('open-pdf', url);
-            }
           }
         },
         { type: 'separator' },
@@ -180,6 +216,11 @@ function setViewerMenu(win) {
           label: 'Save',
           accelerator: 'CmdOrCtrl+S',
           click: () => { if (win) win.webContents.send('save-pdf'); }
+        },
+        {
+          label: 'Save As…',
+          accelerator: 'CmdOrCtrl+Shift+S',
+          click: () => { if (win) win.webContents.send('save-as-pdf'); }
         },
         { type: 'separator' },
         { role: 'close' },
@@ -233,6 +274,15 @@ function createWindow() {
       mainWindow.webContents.send('open-pdf', pdfToOpen);
       pdfToOpen = null;
     }
+  });
+
+  mainWindow.on('close', async (e) => {
+    if (mainWindow.forceClose) return;
+    e.preventDefault();
+    await promptToSave(mainWindow, () => {
+      mainWindow.forceClose = true;
+      mainWindow.close();
+    });
   });
 
   mainWindow.on('closed', () => { mainWindow = null; });

--- a/preload.js
+++ b/preload.js
@@ -10,6 +10,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onMenuUndo: (cb) => ipcRenderer.on('menu-undo', () => cb()),
   onMenuRedo: (cb) => ipcRenderer.on('menu-redo', () => cb()),
   saveFile: (filePath, data) => ipcRenderer.send('save-file', filePath, data),
+  saveFileAs: (filePath, data) => ipcRenderer.invoke('save-file-as', filePath, data),
 
   /* ---------- new: always open links in the default browser ---------- */
   openExternal: (url) => {

--- a/preload.js
+++ b/preload.js
@@ -6,6 +6,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   selectPDF: async () => ipcRenderer.invoke('select-pdf'),
   onOpenPDF: (cb) => ipcRenderer.on('open-pdf', (_e, filePath) => cb(filePath)),
   onSavePDF: (cb) => ipcRenderer.on('save-pdf', () => cb()),
+  onSaveAsPDF: (cb) => ipcRenderer.on('save-as-pdf', () => cb()),
   onMenuUndo: (cb) => ipcRenderer.on('menu-undo', () => cb()),
   onMenuRedo: (cb) => ipcRenderer.on('menu-redo', () => cb()),
   saveFile: (filePath, data) => ipcRenderer.send('save-file', filePath, data),

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -813,8 +813,8 @@ function toSystemPath(url) {
   } catch { return url; }
 }
 
-const originalUrl = decodeURIComponent(new URLSearchParams(location.search).get('file') || '');
-const originalPath = toSystemPath(originalUrl);
+let originalUrl = decodeURIComponent(new URLSearchParams(location.search).get('file') || '');
+let originalPath = toSystemPath(originalUrl);
 
 /* ---- finalize any active drawing so saves/undo see it ---- */
 function commitEditIfAny() {
@@ -841,24 +841,16 @@ async function saveDirect() {
   showSaved();
 }
 
-/* ---- SAVE AS (toolbar download) ---- */
-function clickToolbarSave() {
-  let btn =
-    document.querySelector('[data-tool="save"]') ||
-    document.querySelector('button[aria-label*="Save"]') ||
-    document.querySelector('button[title*="Save"]') ||
-    document.querySelector('a[download]') ||
-    document.getElementById('download');
-
-  if (btn) btn.click();
-  else {
-    const guess = Array.from(document.querySelectorAll('button,a')).find(el => {
-      const t = (el.title || el.ariaLabel || el.textContent || '').toLowerCase();
-      return t.includes('save') || t.includes('download');
-    });
-    guess?.click();
+async function saveAs() {
+  if (!PDFViewerApplication.pdfDocument) return;
+  const data = await PDFViewerApplication.pdfDocument.saveDocument();
+  const newUrl = await window.electronAPI.saveFileAs(originalPath, data);
+  if (newUrl) {
+    originalUrl = newUrl;
+    originalPath = toSystemPath(newUrl);
+    PDFViewerApplication.pdfDocument?.annotationStorage?.resetModified?.();
+    showSaved();
   }
-  PDFViewerApplication.pdfDocument?.annotationStorage?.resetModified?.();
 }
 
 window.electronAPI.onSavePDF(() => {
@@ -868,7 +860,7 @@ window.electronAPI.onSavePDF(() => {
 
 window.electronAPI.onSaveAsPDF(() => {
   commitEditIfAny();
-  setTimeout(clickToolbarSave, 50);
+  saveAs();
 });
 
 document.getElementById('saveButton')?.addEventListener('click', () => {
@@ -877,7 +869,7 @@ document.getElementById('saveButton')?.addEventListener('click', () => {
 });
 document.getElementById('downloadButton')?.addEventListener('click', () => {
   commitEditIfAny();
-  setTimeout(() => PDFViewerApplication.pdfDocument?.annotationStorage?.resetModified?.(), 0);
+  saveAs();
 });
 
 function showSaved() {
@@ -894,7 +886,7 @@ document.addEventListener('keydown', (e) => {
     e.stopPropagation();
     commitEditIfAny();
     if (e.shiftKey) {
-      setTimeout(clickToolbarSave, 50);
+      saveAs();
     } else {
       saveDirect();
     }

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -347,8 +347,11 @@ See https://github.com/adobe-type-tools/cmap-resources
                     <span data-l10n-id="pdfjs-print-button-label"></span>
                   </button>
 
-                  <button id="downloadButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-save-button">
-                    <span data-l10n-id="pdfjs-save-button-label"></span>
+                  <button id="saveButton" class="toolbarButton" type="button" tabindex="0" title="Save">
+                    <span>Save</span>
+                  </button>
+                  <button id="downloadButton" class="toolbarButton" type="button" tabindex="0" title="Save As">
+                    <span>Save As</span>
                   </button>
                 </div>
 
@@ -801,6 +804,18 @@ See https://github.com/adobe-type-tools/cmap-resources
     </div> <!-- outerContainer -->
     <div id="printContainer"></div>
 <script>
+function toSystemPath(url) {
+  try {
+    const u = new URL(url);
+    let p = decodeURIComponent(u.pathname);
+    if (p.startsWith('/') && /^[A-Za-z]:/.test(p.slice(1,3))) p = p.slice(1);
+    return p;
+  } catch { return url; }
+}
+
+const originalUrl = decodeURIComponent(new URLSearchParams(location.search).get('file') || '');
+const originalPath = toSystemPath(originalUrl);
+
 /* ---- finalize any active drawing so saves/undo see it ---- */
 function commitEditIfAny() {
   const doneBtn = document.querySelector(
@@ -818,7 +833,15 @@ function commitEditIfAny() {
   document.dispatchEvent(new KeyboardEvent('keyup',   { key: 'Escape', bubbles: true }));
 }
 
-/* ---- SAVE (uses your toolbar export so edits are kept) ---- */
+async function saveDirect() {
+  if (!originalUrl.startsWith('file:') || !originalPath) return;
+  const data = await PDFViewerApplication.pdfDocument.saveDocument();
+  window.electronAPI.saveFile(originalPath, data);
+  PDFViewerApplication.pdfDocument?.annotationStorage?.resetModified?.();
+  showSaved();
+}
+
+/* ---- SAVE AS (toolbar download) ---- */
 function clickToolbarSave() {
   let btn =
     document.querySelector('[data-tool="save"]') ||
@@ -835,12 +858,54 @@ function clickToolbarSave() {
     });
     guess?.click();
   }
+  PDFViewerApplication.pdfDocument?.annotationStorage?.resetModified?.();
 }
 
 window.electronAPI.onSavePDF(() => {
   commitEditIfAny();
+  saveDirect();
+});
+
+window.electronAPI.onSaveAsPDF(() => {
+  commitEditIfAny();
   setTimeout(clickToolbarSave, 50);
 });
+
+document.getElementById('saveButton')?.addEventListener('click', () => {
+  commitEditIfAny();
+  saveDirect();
+});
+document.getElementById('downloadButton')?.addEventListener('click', () => {
+  commitEditIfAny();
+  setTimeout(() => PDFViewerApplication.pdfDocument?.annotationStorage?.resetModified?.(), 0);
+});
+
+function showSaved() {
+  const alertEl = document.getElementById('viewer-alert');
+  if (!alertEl) return;
+  alertEl.textContent = 'Saved';
+  alertEl.classList.remove('visuallyHidden');
+  setTimeout(() => alertEl.classList.add('visuallyHidden'), 1500);
+}
+
+document.addEventListener('keydown', (e) => {
+  if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 's') {
+    e.preventDefault();
+    e.stopPropagation();
+    commitEditIfAny();
+    if (e.shiftKey) {
+      setTimeout(clickToolbarSave, 50);
+    } else {
+      saveDirect();
+    }
+  }
+}, true);
+
+window.__saveCurrent = saveDirect;
+window.__hasUnsavedChanges = () => {
+  commitEditIfAny();
+  return !!PDFViewerApplication.pdfDocument?.annotationStorage?.modified;
+};
 
 /* ---- UNDO / REDO (click the toolbar buttons; has fallbacks) ---- */
 function clickUndo() {


### PR DESCRIPTION
## Summary
- add `save-file` handler and unsaved-change confirmation before navigating away
- expose `onSavePDF`/`onSaveAsPDF` preload bridges
- handle direct saves, Save As, and unsaved-change detection in the viewer
- add basic README
- ensure unsaved-change prompts always run before navigation and display a small "Saved" indicator with updated Ctrl+S / Ctrl+Shift+S shortcuts

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b134e4d400832b9cefb626ebb7e98a